### PR TITLE
Formatting GoDoc special comment blocks

### DIFF
--- a/api.go
+++ b/api.go
@@ -14,10 +14,10 @@ import (
 // A TelegramBotAPI is an API Client for one Telegram bot.
 // Create a new client by calling the New() function.
 type TelegramBotAPI struct {
-	ID       int            // the bots ID
-	Name     string         // the bots Name as seen by users
-	Username string         // the bots username
-	Updates  chan BotUpdate // a channel providing updates this bot receives
+	ID       int            // The bots ID.
+	Name     string         // The bots Name as seen by users.
+	Username string         // The bots username.
+	Updates  chan BotUpdate // A channel providing updates this bot receives.
 	baseURIs map[method]string
 	closed   chan struct{}
 	c        *client
@@ -31,21 +31,25 @@ type BotUpdate struct {
 	err    error
 }
 
-// Update returns the contained update
+// Update returns the contained update.
 func (u *BotUpdate) Update() Update {
 	return u.update
 }
 
-// Error returns != nil, if an error occurred during retrieval of the update
+// Error returns != nil, if an error occurred during retrieval of the
+// update.
 func (u *BotUpdate) Error() error {
 	return u.err
 }
 
 const apiBaseURI string = "https://api.telegram.org/bot%s"
 
-// New creates a new API Client for a Telegram bot using the apiKey provided.
-// It will call the GetMe method to retrieve the bots id, name and username.
-// Additionally, an update loop is started, pumping updates into the Updates channel.
+// New creates a new API Client for a Telegram bot using the apiKey
+// provided.
+// It will call the GetMe method to retrieve the bots id, name and
+// username.
+// Additionally, an update loop is started, pumping updates into the
+// Updates channel.
 func New(apiKey string) (*TelegramBotAPI, error) {
 	toReturn := TelegramBotAPI{
 		Updates:  make(chan BotUpdate),
@@ -68,8 +72,10 @@ func New(apiKey string) (*TelegramBotAPI, error) {
 }
 
 // Close shuts down this client.
-// Until Close returns, new updates and errors will be put into the respective channels.
-// Note that, if no updates are received, this function may block for up to one minute, which is the time interval
+// Until Close returns, new updates and errors will be put into the
+// respective channels.
+// Note that, if no updates are received, this function may block for up to
+// one minute, which is the time interval
 // for long polling.
 func (api *TelegramBotAPI) Close() {
 	select {
@@ -173,9 +179,11 @@ func (api *TelegramBotAPI) GetMe() (*UserResponse, error) {
 	return resp, nil
 }
 
-// GetFile returns a FileResponse containing a Path string needed to download a file.
+// GetFile returns a FileResponse containing a Path string needed to
+// download a file.
 // You will have to construct the download link manually like
-// https://api.telegram.org/file/bot<token>/<file_path>, where <file_path> is taken from the response.
+// https://api.telegram.org/file/bot<token>/<file_path>, where <file_path>
+// is taken from the response.
 func (api *TelegramBotAPI) GetFile(fileID string) (*FileResponse, error) {
 	resp := &FileResponse{}
 	_, err := api.c.getQuerystring(getFile, resp, map[string]string{"file_id": fileID})
@@ -198,7 +206,8 @@ func check(br *baseResponse) error {
 	return fmt.Errorf("tbotapi: API error: %d - %s", br.ErrorCode, br.Description)
 }
 
-// ErrNoFileSpecified is returned in case neither a file name + io.Reader nor a fileID were specified
+// ErrNoFileSpecified is returned in case neither a file name + io.Reader
+// nor a fileID were specified.
 var ErrNoFileSpecified = errors.New("tbotapi: Neither a fileID nor a fileName/reader were specified")
 
 func (api *TelegramBotAPI) send(s sendable) (resp *MessageResponse, err error) {

--- a/ctors.go
+++ b/ctors.go
@@ -6,7 +6,7 @@ package tbotapi
 
 import "io"
 
-// NewOutgoingMessage creates a new outgoing message
+// NewOutgoingMessage creates a new outgoing message.
 func (api *TelegramBotAPI) NewOutgoingMessage(recipient Recipient, text string) *OutgoingMessage {
 	return &OutgoingMessage{
 		outgoingMessageBase: outgoingMessageBase{
@@ -20,7 +20,7 @@ func (api *TelegramBotAPI) NewOutgoingMessage(recipient Recipient, text string) 
 	}
 }
 
-// NewOutgoingLocation creates a new outgoing location
+// NewOutgoingLocation creates a new outgoing location.
 func (api *TelegramBotAPI) NewOutgoingLocation(recipient Recipient, latitude, longitude float32) *OutgoingLocation {
 	return &OutgoingLocation{
 		outgoingMessageBase: outgoingMessageBase{
@@ -34,7 +34,7 @@ func (api *TelegramBotAPI) NewOutgoingLocation(recipient Recipient, latitude, lo
 	}
 }
 
-// NewOutgoingVenue creates a new outgoing location
+// NewOutgoingVenue creates a new outgoing location.
 func (api *TelegramBotAPI) NewOutgoingVenue(recipient Recipient, latitude, longitude float32, title, address string) *OutgoingVenue {
 	return &OutgoingVenue{
 		outgoingMessageBase: outgoingMessageBase{
@@ -50,7 +50,7 @@ func (api *TelegramBotAPI) NewOutgoingVenue(recipient Recipient, latitude, longi
 	}
 }
 
-// NewOutgoingVideo creates a new outgoing video file
+// NewOutgoingVideo creates a new outgoing video file.
 func (api *TelegramBotAPI) NewOutgoingVideo(recipient Recipient, fileName string, reader io.Reader) *OutgoingVideo {
 	return &OutgoingVideo{
 		outgoingMessageBase: outgoingMessageBase{
@@ -66,7 +66,7 @@ func (api *TelegramBotAPI) NewOutgoingVideo(recipient Recipient, fileName string
 	}
 }
 
-// NewOutgoingVideoResend creates a new outgoing video file for re-sending
+// NewOutgoingVideoResend creates a new outgoing video file for re-sending.
 func (api *TelegramBotAPI) NewOutgoingVideoResend(recipient Recipient, fileID string) *OutgoingVideo {
 	return &OutgoingVideo{
 		outgoingMessageBase: outgoingMessageBase{
@@ -81,7 +81,7 @@ func (api *TelegramBotAPI) NewOutgoingVideoResend(recipient Recipient, fileID st
 	}
 }
 
-// NewOutgoingPhoto creates a new outgoing photo
+// NewOutgoingPhoto creates a new outgoing photo.
 func (api *TelegramBotAPI) NewOutgoingPhoto(recipient Recipient, fileName string, reader io.Reader) *OutgoingPhoto {
 	return &OutgoingPhoto{
 		outgoingMessageBase: outgoingMessageBase{
@@ -97,7 +97,7 @@ func (api *TelegramBotAPI) NewOutgoingPhoto(recipient Recipient, fileName string
 	}
 }
 
-// NewOutgoingPhotoResend creates a new outgoing photo for re-sending
+// NewOutgoingPhotoResend creates a new outgoing photo for re-sending.
 func (api *TelegramBotAPI) NewOutgoingPhotoResend(recipient Recipient, fileID string) *OutgoingPhoto {
 	return &OutgoingPhoto{
 		outgoingMessageBase: outgoingMessageBase{
@@ -112,7 +112,7 @@ func (api *TelegramBotAPI) NewOutgoingPhotoResend(recipient Recipient, fileID st
 	}
 }
 
-// NewOutgoingSticker creates a new outgoing sticker message
+// NewOutgoingSticker creates a new outgoing sticker message.
 func (api *TelegramBotAPI) NewOutgoingSticker(recipient Recipient, fileName string, reader io.Reader) *OutgoingSticker {
 	return &OutgoingSticker{
 		outgoingMessageBase: outgoingMessageBase{
@@ -128,7 +128,8 @@ func (api *TelegramBotAPI) NewOutgoingSticker(recipient Recipient, fileName stri
 	}
 }
 
-// NewOutgoingStickerResend creates a new outgoing sticker message for re-sending
+// NewOutgoingStickerResend creates a new outgoing sticker message for
+// re-sending.
 func (api *TelegramBotAPI) NewOutgoingStickerResend(recipient Recipient, fileID string) *OutgoingSticker {
 	return &OutgoingSticker{
 		outgoingMessageBase: outgoingMessageBase{
@@ -143,7 +144,7 @@ func (api *TelegramBotAPI) NewOutgoingStickerResend(recipient Recipient, fileID 
 	}
 }
 
-// NewOutgoingVoice creates a new outgoing voice note
+// NewOutgoingVoice creates a new outgoing voice note.
 func (api *TelegramBotAPI) NewOutgoingVoice(recipient Recipient, fileName string, reader io.Reader) *OutgoingVoice {
 	return &OutgoingVoice{
 		outgoingMessageBase: outgoingMessageBase{
@@ -159,7 +160,7 @@ func (api *TelegramBotAPI) NewOutgoingVoice(recipient Recipient, fileName string
 	}
 }
 
-// NewOutgoingVoiceResend creates a new outgoing voice note for re-sending
+// NewOutgoingVoiceResend creates a new outgoing voice note for re-sending.
 func (api *TelegramBotAPI) NewOutgoingVoiceResend(recipient Recipient, fileID string) *OutgoingVoice {
 	return &OutgoingVoice{
 		outgoingMessageBase: outgoingMessageBase{
@@ -174,7 +175,7 @@ func (api *TelegramBotAPI) NewOutgoingVoiceResend(recipient Recipient, fileID st
 	}
 }
 
-// NewOutgoingAudio creates a new outgoing audio file
+// NewOutgoingAudio creates a new outgoing audio file.
 func (api *TelegramBotAPI) NewOutgoingAudio(recipient Recipient, fileName string, reader io.Reader) *OutgoingAudio {
 	return &OutgoingAudio{
 		outgoingMessageBase: outgoingMessageBase{
@@ -190,7 +191,7 @@ func (api *TelegramBotAPI) NewOutgoingAudio(recipient Recipient, fileName string
 	}
 }
 
-// NewOutgoingAudioResend creates a new outgoing audio file for re-sending
+// NewOutgoingAudioResend creates a new outgoing audio file for re-sending.
 func (api *TelegramBotAPI) NewOutgoingAudioResend(recipient Recipient, fileID string) *OutgoingAudio {
 	return &OutgoingAudio{
 		outgoingMessageBase: outgoingMessageBase{
@@ -205,7 +206,7 @@ func (api *TelegramBotAPI) NewOutgoingAudioResend(recipient Recipient, fileID st
 	}
 }
 
-// NewOutgoingDocument creates a new outgoing file
+// NewOutgoingDocument creates a new outgoing file.
 func (api *TelegramBotAPI) NewOutgoingDocument(recipient Recipient, fileName string, reader io.Reader) *OutgoingDocument {
 	return &OutgoingDocument{
 		outgoingMessageBase: outgoingMessageBase{
@@ -221,7 +222,7 @@ func (api *TelegramBotAPI) NewOutgoingDocument(recipient Recipient, fileName str
 	}
 }
 
-// NewOutgoingDocumentResend creates a new outgoing file for re-sending
+// NewOutgoingDocumentResend creates a new outgoing file for re-sending.
 func (api *TelegramBotAPI) NewOutgoingDocumentResend(recipient Recipient, fileID string) *OutgoingDocument {
 	return &OutgoingDocument{
 		outgoingMessageBase: outgoingMessageBase{
@@ -236,7 +237,7 @@ func (api *TelegramBotAPI) NewOutgoingDocumentResend(recipient Recipient, fileID
 	}
 }
 
-// NewOutgoingForward creates a new outgoing, forwarded message
+// NewOutgoingForward creates a new outgoing, forwarded message.
 func (api *TelegramBotAPI) NewOutgoingForward(recipient Recipient, origin Chat, messageID int) *OutgoingForward {
 	return &OutgoingForward{
 		outgoingMessageBase: outgoingMessageBase{
@@ -250,7 +251,7 @@ func (api *TelegramBotAPI) NewOutgoingForward(recipient Recipient, origin Chat, 
 	}
 }
 
-// NewOutgoingChatAction creates a new outgoing chat action
+// NewOutgoingChatAction creates a new outgoing chat action.
 func (api *TelegramBotAPI) NewOutgoingChatAction(recipient Recipient, action ChatAction) *OutgoingChatAction {
 	return &OutgoingChatAction{
 		outgoingBase: outgoingBase{
@@ -261,7 +262,8 @@ func (api *TelegramBotAPI) NewOutgoingChatAction(recipient Recipient, action Cha
 	}
 }
 
-// NewOutgoingUserProfilePhotosRequest creates a new request for a users profile photos
+// NewOutgoingUserProfilePhotosRequest creates a new request for a users
+// profile photos.
 func (api *TelegramBotAPI) NewOutgoingUserProfilePhotosRequest(userID int) *OutgoingUserProfilePhotosRequest {
 	return &OutgoingUserProfilePhotosRequest{
 		api:    api,
@@ -269,7 +271,8 @@ func (api *TelegramBotAPI) NewOutgoingUserProfilePhotosRequest(userID int) *Outg
 	}
 }
 
-// NewOutgoingKickChatMember creates a request to kick a member from a group chat or channel.
+// NewOutgoingKickChatMember creates a request to kick a member from a
+// group chat or channel.
 func (api *TelegramBotAPI) NewOutgoingKickChatMember(chat Recipient, userID int) *OutgoingKickChatMember {
 	return &OutgoingKickChatMember{
 		api:       api,
@@ -278,7 +281,8 @@ func (api *TelegramBotAPI) NewOutgoingKickChatMember(chat Recipient, userID int)
 	}
 }
 
-// NewOutgoingUnbanChatMember creates a request to unban a member of a group chat or channel.
+// NewOutgoingUnbanChatMember creates a request to unban a member of a
+// group chat or channel.
 func (api *TelegramBotAPI) NewOutgoingUnbanChatMember(chat Recipient, userID int) *OutgoingUnbanChatMember {
 	return &OutgoingUnbanChatMember{
 		api:       api,
@@ -295,7 +299,7 @@ func (api *TelegramBotAPI) NewOutgoingCallbackQueryResponse(queryID string) *Out
 	}
 }
 
-// NewInlineQueryAnswer creates a new inline query answer
+// NewInlineQueryAnswer creates a new inline query answer.
 func (api *TelegramBotAPI) NewInlineQueryAnswer(queryID string, results []InlineQueryResult) *InlineQueryAnswer {
 	return &InlineQueryAnswer{
 		api:     api,

--- a/doc.go
+++ b/doc.go
@@ -4,13 +4,16 @@
 
 // Package tbotapi provides a Go wrapper for the Telegram Messenger Bot API.
 //
-// Note that, if the REST API returns an error, that error will be wrapped in a Go error.
+// Note that, if the REST API returns an error, that error will be wrapped
+// in a Go error.
 //
-// We currently only support long polling (i.e. no webhooks). Feature-wise, everything up to and including the January 20
-// changes should be implemented.
+// We currently only support long polling (i.e. no webhooks).
+// Feature-wise, everything up to and including the January 20 changes should
+// be implemented.
 //
 // Examples are provided in the examples package, so check that out.
 //
-// The Bot API imposes certain limitations, these are especially interesting for inline query results and files. This
-// library does not keep track of those limitations, so you'll have to perform checks yourself.
+// The Bot API imposes certain limitations, these are especially interesting
+// for inline query results and files. This library does not keep track of
+// those limitations, so you'll have to perform checks yourself.
 package tbotapi

--- a/examples/boilerplate/boilerplate.go
+++ b/examples/boilerplate/boilerplate.go
@@ -15,12 +15,13 @@ import (
 	"github.com/mrd0ll4r/tbotapi"
 )
 
-// BotFunc describes how the bot handles an update
+// BotFunc describes how the bot handles an update.
 type BotFunc func(update tbotapi.Update, api *tbotapi.TelegramBotAPI)
 
 // RunBot runs a bot.
 // THIS IS JUST FOR DEMONSTRATION! NOT TO BE USED IN PRODUCTION!
-// It will block until either something very bad happens or closing is closed.
+// It will block until either something very bad happens or closing is
+// closed.
 func RunBot(apiKey string, bot BotFunc, name, description string) {
 	fmt.Printf("%s: %s\n", name, description)
 	fmt.Println("Starting...")
@@ -30,7 +31,7 @@ func RunBot(apiKey string, bot BotFunc, name, description string) {
 		log.Fatal(err)
 	}
 
-	// just to show its working
+	// Just to show its working.
 	fmt.Printf("User ID: %d\n", api.ID)
 	fmt.Printf("Bot Name: %s\n", api.Name)
 	fmt.Printf("Bot Username: %s\n", api.Username)
@@ -56,7 +57,7 @@ func RunBot(apiKey string, bot BotFunc, name, description string) {
 		}
 	}()
 
-	// ensure a clean shutdown
+	// Ensure a clean shutdown.
 	closing := make(chan struct{})
 	shutdown := make(chan os.Signal)
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
@@ -70,12 +71,12 @@ func RunBot(apiKey string, bot BotFunc, name, description string) {
 
 	fmt.Println("Bot started. Press CTRL-C to close...")
 
-	// wait for the signal
+	// Wait for the signal.
 	<-closing
 	fmt.Println("Closing...")
 
-	// always close the API first, let it clean up the update loop
-	api.Close() //this might take a while
+	// Always close the API first, let it clean up the update loop.
+	api.Close() // This might take a while.
 	close(closed)
 	wg.Wait()
 }

--- a/examples/chatAction.go
+++ b/examples/chatAction.go
@@ -21,15 +21,15 @@ func main() {
 			msg := update.Message
 			typ := msg.Type()
 			if typ != tbotapi.TextMessage {
-				//ignore non-text messages for now
+				// Ignore non-text messages for now.
 				fmt.Println("Ignoring non-text message")
 				return
 			}
-			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here
+			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here.
 
-			// display the incoming message
-			// msg.Chat implements fmt.Stringer, so it'll display nicely
-			// we know it's a text message, so we can safely use the Message.Text pointer
+			// Display the incoming message.
+			// msg.Chat implements fmt.Stringer, so it'll display nicely.
+			// We know it's a text message, so we can safely use the Message.Text pointer.
 			fmt.Printf("<-%d, From:\t%s, Text: %s \n", msg.ID, msg.Chat, *msg.Text)
 
 			fmt.Printf("Sending ChatActionTyping to %s\n", msg.Chat)
@@ -40,7 +40,7 @@ func main() {
 			}
 			time.Sleep(2 * time.Second)
 
-			// clear chat action
+			// Clear chat action.
 			outMsg, err := api.NewOutgoingMessage(tbotapi.NewRecipientFromChat(msg.Chat), "Finished typing.").Send()
 
 			if err != nil {
@@ -57,7 +57,7 @@ func main() {
 			}
 			time.Sleep(2 * time.Second)
 
-			// clear chat action and tell them we're done
+			// Clear chat action and tell them we're done.
 			outMsg, err = api.NewOutgoingMessage(tbotapi.NewRecipientFromChat(msg.Chat), "Done").Send()
 
 			if err != nil {
@@ -74,6 +74,6 @@ func main() {
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "ChatAction", "Demonstrates chat actions")
 }

--- a/examples/echo.go
+++ b/examples/echo.go
@@ -20,18 +20,18 @@ func main() {
 			msg := update.Message
 			typ := msg.Type()
 			if typ != tbotapi.TextMessage {
-				//ignore non-text messages for now
+				// Ignore non-text messages for now.
 				fmt.Println("Ignoring non-text message")
 				return
 			}
-			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here
+			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here.
 
-			// display the incoming message
-			// msg.Chat implements fmt.Stringer, so it'll display nicely
-			// we know it's a text message, so we can safely use the Message.Text pointer
+			// Display the incoming message.
+			// msg.Chat implements fmt.Stringer, so it'll display nicely.
+			// We know it's a text message, so we can safely use the Message.Text pointer.
 			fmt.Printf("<-%d, From:\t%s, Text: %s \n", msg.ID, msg.Chat, *msg.Text)
 
-			// now simply echo that back
+			// Now simply echo that back.
 			outMsg, err := api.NewOutgoingMessage(tbotapi.NewRecipientFromChat(msg.Chat), *msg.Text).Send()
 
 			if err != nil {
@@ -48,6 +48,6 @@ func main() {
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "Echo", "Echoes messages back")
 }

--- a/examples/forward.go
+++ b/examples/forward.go
@@ -20,18 +20,18 @@ func main() {
 			msg := update.Message
 			typ := msg.Type()
 			if typ != tbotapi.TextMessage {
-				//ignore non-text messages for now
+				// Ignore non-text messages for now.
 				fmt.Println("Ignoring non-text message")
 				return
 			}
-			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here
+			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here.
 
-			// display the incoming message
-			// msg.Chat implements fmt.Stringer, so it'll display nicely
-			// we know it's a text message, so we can safely use the Message.Text pointer
+			// Display the incoming message.
+			// msg.Chat implements fmt.Stringer, so it'll display nicely.
+			// We know it's a text message, so we can safely use the Message.Text pointer.
 			fmt.Printf("<-%d, From:\t%s, Text: %s \n", msg.ID, msg.Chat, *msg.Text)
 
-			// now simply forward that back
+			// Now simply forward that back.
 			outMsg, err := api.NewOutgoingForward(tbotapi.NewRecipientFromChat(msg.Chat), msg.Chat, msg.ID).Send()
 
 			if err != nil {
@@ -48,6 +48,6 @@ func main() {
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "Forward", "Forwards messages back")
 }

--- a/examples/inlineQuery.go
+++ b/examples/inlineQuery.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	apiToken := "123456789:Your_API_token_goes_here"
 
-	// Note: For this example to work, you'll have to enable inline queries for your bot (chat with @BotFather)
+	// Note: For this example to work, you'll have to enable inline queries for your bot (chat with @BotFather).
 
 	updateFunc := func(update tbotapi.Update, api *tbotapi.TelegramBotAPI) {
 		switch update.Type() {
@@ -28,11 +28,11 @@ func main() {
 
 			for i, s := range query.Query {
 				if len(results) >= 50 {
-					// the API accepts up to 50 results
+					// The API accepts up to 50 results.
 					break
 				}
 				if !unicode.IsSpace(s) {
-					// don't set mandatory fields to whitespace
+					// Don't set mandatory fields to whitespace.
 					results = append(results, tbotapi.NewInlineQueryResultArticle(fmt.Sprint(i), string(s), string(s)))
 				}
 			}
@@ -42,13 +42,13 @@ func main() {
 				fmt.Printf("Err: %s\n", err)
 			}
 		case tbotapi.ChosenInlineResultUpdate:
-			//id, not value
+			// id, not value.
 			fmt.Println("Chosen inline query result (ID):", update.ChosenInlineResult.ID)
 		default:
 			fmt.Printf("Ignoring unknown Update type.")
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "InlineQuery", "Demonstrates inline queries by splitting words")
 }

--- a/examples/keyboardMarkup.go
+++ b/examples/keyboardMarkup.go
@@ -21,29 +21,29 @@ func main() {
 			msg := update.Message
 			typ := msg.Type()
 			if typ.IsChatAction() {
-				//ignore chat actions, like group creates or joins
+				// Ignore chat actions, like group creates or joins.
 				fmt.Println("Ignoring chat action")
 				return
 			}
 			if msg.Chat.IsChannel() {
-				//ignore messages _about_ channels (bots cannot receive from channels, but will probably get events like channel creations)
+				// Ignore messages _about_ channels (bots cannot receive from channels, but will probably get events like channel creations).
 				fmt.Println("Ignoring channel message")
 				return
 			}
 
-			// display the incoming message
-			// msg.Chat implements fmt.Stringer, so it'll display nicely
-			// MessageType implements fmt.Stringer, so it'll display nicely
+			// Display the incoming message.
+			// msg.Chat implements fmt.Stringer, so it'll display nicely.
+			// MessageType implements fmt.Stringer, so it'll display nicely.
 			fmt.Printf("<-%d, From:\t%s, Type: %s \n", msg.ID, msg.Chat, typ)
 
-			// create a message with some keyboard markup
+			// Create a message with some keyboard markup.
 			toSend := api.NewOutgoingMessage(tbotapi.NewRecipientFromChat(msg.Chat), "What time is it where I am?")
 			toSend.SetReplyKeyboardMarkup(tbotapi.ReplyKeyboardMarkup{
 				Keyboard:        [][]tbotapi.KeyboardButton{[]tbotapi.KeyboardButton{tbotapi.KeyboardButton{Text: time.Now().Format(time.RFC1123Z)}}},
 				OneTimeKeyboard: true,
 			})
 
-			// send it
+			// Send it.
 			outMsg, err := toSend.Send()
 
 			if err != nil {
@@ -60,6 +60,6 @@ func main() {
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "KeyboardMarkup", "Demonstrates keyboard markup")
 }

--- a/examples/markup.go
+++ b/examples/markup.go
@@ -20,18 +20,18 @@ func main() {
 			msg := update.Message
 			typ := msg.Type()
 			if typ != tbotapi.TextMessage {
-				//ignore non-text messages for now
+				// Ignore non-text messages for now.
 				fmt.Println("Ignoring non-text message")
 				return
 			}
-			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here
+			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here.
 
-			// display the incoming message
-			// msg.Chat implements fmt.Stringer, so it'll display nicely
-			// we know it's a text message, so we can safely use the Message.Text pointer
+			// Display the incoming message.
+			// msg.Chat implements fmt.Stringer, so it'll display nicely.
+			// We know it's a text message, so we can safely use the Message.Text pointer.
 			fmt.Printf("<-%d, From:\t%s, Text: %s \n", msg.ID, msg.Chat, *msg.Text)
 
-			// now let's send a markdown-formatted message
+			// Now let's send a markdown-formatted message.
 			outMsg, err := api.NewOutgoingMessage(tbotapi.NewRecipientFromChat(msg.Chat),
 				"This is _formatted_ *text* with [links](https://google.com)").SetMarkdown(true).Send()
 
@@ -41,7 +41,7 @@ func main() {
 			}
 			fmt.Printf("->%d, To:\t%s, Text: %s\n", outMsg.Message.ID, outMsg.Message.Chat, *outMsg.Message.Text)
 
-			// and now with HTML
+			// And now with HTML.
 			outMsg, err = api.NewOutgoingMessage(tbotapi.NewRecipientFromChat(msg.Chat),
 				"This is <i>formatted</i> <b>text</b> with <a href=\"https://google.com\">links</a>").SetHTML(true).Send()
 
@@ -59,6 +59,6 @@ func main() {
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "Markup", "Demonstrates markdown and HTML markup")
 }

--- a/examples/photo.go
+++ b/examples/photo.go
@@ -21,25 +21,25 @@ func main() {
 			msg := update.Message
 			typ := msg.Type()
 			if typ != tbotapi.TextMessage {
-				//ignore non-text messages for now
+				// Ignore non-text messages for now.
 				fmt.Println("Ignoring non-text message")
 				return
 			}
-			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here
+			// Note: Bots cannot receive from channels, at least no text messages. So we don't have to distinguish anything here.
 
-			// display the incoming message
-			// msg.Chat implements fmt.Stringer, so it'll display nicely
-			// we know it's a text message, so we can safely use the Message.Text pointer
+			// Display the incoming message.
+			// msg.Chat implements fmt.Stringer, so it'll display nicely.
+			// We know it's a text message, so we can safely use the Message.Text pointer.
 			fmt.Printf("<-%d, From:\t%s, Text: %s \n", msg.ID, msg.Chat, *msg.Text)
 
-			// send a photo
+			// Send a photo.
 			file, err := os.Open("data/example.png")
 			if err != nil {
 				fmt.Printf("Error opening file: %s\n", err)
 				return
 			}
 			defer file.Close()
-			// Note: Set at least a correct file extension, the API will check this
+			// Note: Set at least a correct file extension, the API will check this.
 			outMsg, err := api.NewOutgoingPhoto(tbotapi.NewRecipientFromChat(msg.Chat), "example.png", file).Send()
 
 			if err != nil {
@@ -56,6 +56,6 @@ func main() {
 		}
 	}
 
-	// run the bot, this will block
+	// Run the bot, this will block.
 	boilerplate.RunBot(apiToken, updateFunc, "Photo", "Always responds to text messages with a picture")
 }

--- a/incoming.go
+++ b/incoming.go
@@ -7,46 +7,46 @@ package tbotapi
 import "fmt"
 import "sort"
 
-// BaseResponse contains the basic fields contained in every API response
+// BaseResponse contains the basic fields contained in every API response.
 type baseResponse struct {
 	Ok          bool   `json:"ok"`
 	Description string `json:"description"`
 	ErrorCode   int    `json:"error_code"`
 }
 
-// Audio represents an audio file to be treated as music
+// Audio represents an audio file to be treated as music.
 type Audio struct {
 	FileBase
 	Duration int    `json:"duration"`
 	MimeType string `json:"mime_type"`
 }
 
-// Chat contains information about the chat a message originated from
+// Chat contains information about the chat a message originated from.
 type Chat struct {
-	ID        int     `json:"id"`         // Unique identifier for this chat
-	Type      string  `json:"type"`       // Type of chat, can be either "private", "group" or "channel". Check Is(PrivateChat|GroupChat|Channel)() methods
-	Title     *string `json:"title"`      // Title for channels and group chats
-	Username  *string `json:"username"`   // Username for private chats and channels if available
-	FirstName *string `json:"first_name"` // First name of the other party in a private chat
-	LastName  *string `json:"last_name"`  // Last name of the other party in a private chat
+	ID        int     `json:"id"`         // Unique identifier for this chat.
+	Type      string  `json:"type"`       // Type of chat, can be either "private", "group" or "channel". Check Is(PrivateChat|GroupChat|Channel)() methods.
+	Title     *string `json:"title"`      // Title for channels and group chats.
+	Username  *string `json:"username"`   // Username for private chats and channels if available.
+	FirstName *string `json:"first_name"` // First name of the other party in a private chat.
+	LastName  *string `json:"last_name"`  // Last name of the other party in a private chat.
 }
 
-// IsPrivateChat checks if the chat is a private chat
+// IsPrivateChat checks if the chat is a private chat.
 func (c Chat) IsPrivateChat() bool {
 	return c.Type == "private"
 }
 
-// IsGroupChat checks if the chat is a group chat
+// IsGroupChat checks if the chat is a group chat.
 func (c Chat) IsGroupChat() bool {
 	return c.Type == "group"
 }
 
-// IsSupergroup checks if the chat is a supergroup chat
+// IsSupergroup checks if the chat is a supergroup chat.
 func (c Chat) IsSupergroup() bool {
 	return c.Type == "supergroup"
 }
 
-// IsChannel checks if the chat is a channel
+// IsChannel checks if the chat is a channel.
 func (c Chat) IsChannel() bool {
 	return c.Type == "channel"
 }
@@ -80,7 +80,7 @@ func (c Chat) String() string {
 	return toReturn
 }
 
-// Contact represents a phone contact
+// Contact represents a phone contact.
 type Contact struct {
 	PhoneNumber string `json:"phone_number"`
 	FirstName   string `json:"first_name"`
@@ -88,7 +88,7 @@ type Contact struct {
 	ID          int    `json:"user_id"`
 }
 
-// Document represents a general file
+// Document represents a general file.
 type Document struct {
 	FileBase
 	Thumbnail PhotoSize `json:"thumb"`
@@ -96,54 +96,57 @@ type Document struct {
 	MimeType  string    `json:"mime_type"`
 }
 
-// FileBase contains all the fields present in every file-like API response
+// FileBase contains all the fields present in every file-like API response.
 type FileBase struct {
 	ID   string `json:"file_id"`
 	Size int    `json:"file_size"`
 }
 
-// File represents a file ready to be downloaded
+// File represents a file ready to be downloaded.
 type File struct {
 	FileBase
 	Path string `json:"file_path"`
 }
 
-// FileResponse represents the response sent by the API when requesting a file for download
+// FileResponse represents the response sent by the API when requesting a
+// file for download.
 type FileResponse struct {
 	baseResponse
 	File File `json:"result"`
 }
 
-// Location represents a point on the map
+// Location represents a point on the map.
 type Location struct {
 	Longitude float32 `json:"longitude"`
 	Latitude  float32 `json:"latitude"`
 }
 
-// MessageResponse represents the response sent by the API on successful messages sent
+// MessageResponse represents the response sent by the API on successful
+// messages sent.
 type MessageResponse struct {
 	baseResponse
 	Message Message `json:"result"`
 }
 
-// Message represents a message
+// Message represents a message.
 type Message struct {
 	noReplyMessage
 	ReplyToMessage *noReplyMessage `json:"reply_to_message"`
 }
 
-// IsForwarded checks if the message was forwarded
+// IsForwarded checks if the message was forwarded.
 func (m *Message) IsForwarded() bool {
 	return m.ForwardFrom != nil
 }
 
-// IsReply checks if the message is a reply
+// IsReply checks if the message is a reply.
 func (m *Message) IsReply() bool {
 	return m.ReplyToMessage != nil
 }
 
 // Type determines the type of the message.
-// Note that, for all these types, messages can still be replies or forwarded.
+// Note that, for all these types, messages can still be replies or
+// forwarded.
 func (m *Message) Type() MessageType {
 	if m.Text != nil {
 		return TextMessage
@@ -193,34 +196,34 @@ func (m *Message) Type() MessageType {
 }
 
 type noReplyMessage struct {
-	Chat                  Chat             `json:"chat"`                    // information about the chat
-	ID                    int              `json:"message_id"`              // message id
-	From                  User             `json:"from"`                    // sender
-	Date                  int              `json:"date"`                    // timestamp
-	ForwardFrom           *User            `json:"forward_from"`            // forwarded from who
-	ForwardDate           *int             `json:"forward_date"`            // forwarded from when
-	Text                  *string          `json:"text"`                    // the actual text content
-	Entities              *[]MessageEntity `json:"entities"`                // For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text (optional)
-	Caption               *string          `json:"caption"`                 // caption for photo or video messages
-	Audio                 *Audio           `json:"audio"`                   // information about audio contents
-	Document              *Document        `json:"document"`                // information about file contents
-	Photo                 *[]PhotoSize     `json:"photo"`                   // information about photo contents
-	Sticker               *Sticker         `json:"sticker"`                 // information about sticker contents
-	Video                 *Video           `json:"video"`                   // information about video contents
-	Voice                 *Voice           `json:"voice"`                   // information about voice message contents
-	Contact               *Contact         `json:"contact"`                 // information about contact contents
-	Location              *Location        `json:"location"`                // information about location contents
-	Venue                 *Venue           `json:"venue"`                   // information about venue contents
-	NewChatMember         *User            `json:"new_chat_member"`         // information about a new chat participant
-	LeftChatMember        *User            `json:"left_chat_member"`        // information about a chat participant who left
-	NewChatTitle          *string          `json:"new_chat_title"`          // information about changes in the group name
-	NewChatPhoto          *[]PhotoSize     `json:"new_chat_photo"`          // information about a new chat photo
-	DeleteChatPhoto       bool             `json:"delete_chat_photo"`       // information about a deleted chat photo
-	GroupChatCreated      bool             `json:"group_chat_created"`      // information about a created group chat
-	SupergroupChatCreated bool             `json:"supergroup_chat_created"` // information about a created supergroup chat
-	ChannelChatCreated    bool             `json:"channel_chat_created"`    // information about a created channel
-	MigrateToChatID       *int             `json:"migrate_to_chat_id"`      // indicates the chat ID the group chat was migrated to (is now a supergroup)
-	MigrateFromChatID     *int             `json:"migrate_from_chat_id"`    // indicates the chat ID the now supergroup chat was migrated from
+	Chat                  Chat             `json:"chat"`                    // Information about the chat.
+	ID                    int              `json:"message_id"`              // Message id.
+	From                  User             `json:"from"`                    // Sender.
+	Date                  int              `json:"date"`                    // Timestamp.
+	ForwardFrom           *User            `json:"forward_from"`            // Forwarded from who.
+	ForwardDate           *int             `json:"forward_date"`            // Forwarded from when.
+	Text                  *string          `json:"text"`                    // The actual text content.
+	Entities              *[]MessageEntity `json:"entities"`                // For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text (optional).
+	Caption               *string          `json:"caption"`                 // Caption for photo or video messages.
+	Audio                 *Audio           `json:"audio"`                   // Information about audio contents.
+	Document              *Document        `json:"document"`                // Information about file contents.
+	Photo                 *[]PhotoSize     `json:"photo"`                   // Information about photo contents.
+	Sticker               *Sticker         `json:"sticker"`                 // Information about sticker contents.
+	Video                 *Video           `json:"video"`                   // Information about video contents.
+	Voice                 *Voice           `json:"voice"`                   // Information about voice message contents.
+	Contact               *Contact         `json:"contact"`                 // Information about contact contents.
+	Location              *Location        `json:"location"`                // Information about location contents.
+	Venue                 *Venue           `json:"venue"`                   // Information about venue contents.
+	NewChatMember         *User            `json:"new_chat_member"`         // Information about a new chat participant.
+	LeftChatMember        *User            `json:"left_chat_member"`        // Information about a chat participant who left.
+	NewChatTitle          *string          `json:"new_chat_title"`          // Information about changes in the group name.
+	NewChatPhoto          *[]PhotoSize     `json:"new_chat_photo"`          // Information about a new chat photo.
+	DeleteChatPhoto       bool             `json:"delete_chat_photo"`       // Information about a deleted chat photo.
+	GroupChatCreated      bool             `json:"group_chat_created"`      // Information about a created group chat.
+	SupergroupChatCreated bool             `json:"supergroup_chat_created"` // Information about a created supergroup chat.
+	ChannelChatCreated    bool             `json:"channel_chat_created"`    // Information about a created channel.
+	MigrateToChatID       *int             `json:"migrate_to_chat_id"`      // Indicates the chat ID the group chat was migrated to (is now a supergroup).
+	MigrateFromChatID     *int             `json:"migrate_from_chat_id"`    // Indicates the chat ID the now supergroup chat was migrated from.
 	PinnedMessage         *noReplyMessage  `json:"pinned_message"`
 }
 
@@ -251,43 +254,43 @@ type MessageEntity struct {
 
 // Venue represents a venue contained in a message.
 type Venue struct {
-	Location     Location `json:"location"`     // venue location
-	Title        string   `json:"title"`        // Name of the venue
-	Address      string   `json:"address"`      // Address of the venue
-	FoursquareID *string  `json:"foursqare_id"` // Foursqare ID of the venue (optional)
+	Location     Location `json:"location"`     // Venue location.
+	Title        string   `json:"title"`        // Name of the venue.
+	Address      string   `json:"address"`      // Address of the venue.
+	FoursquareID *string  `json:"foursqare_id"` // Foursqare ID of the venue (optional).
 }
 
-// MessageType is the type of a message
+// MessageType is the type of a message.
 type MessageType int
 
-// Message types
+// Message types.
 const (
-	TextMessage     MessageType = iota // text messages
-	PinnedMessage                      // pinned messages
-	AudioMessage                       // audio messages
-	DocumentMessage                    // files
-	PhotoMessage                       // photos
-	StickerMessage                     // stickers
-	VideoMessage                       // videos
-	VoiceMessage                       // voice messages
-	ContactMessage                     // contact information
-	LocationMessage                    // locations
-	VenueMessage                       // venues
+	TextMessage     MessageType = iota // Text messages.
+	PinnedMessage                      // Pinned messages.
+	AudioMessage                       // Audio messages.
+	DocumentMessage                    // Files.
+	PhotoMessage                       // Photos.
+	StickerMessage                     // Stickers.
+	VideoMessage                       // Videos.
+	VoiceMessage                       // Voice messages.
+	ContactMessage                     // Contact information.
+	LocationMessage                    // Locations.
+	VenueMessage                       // Venues.
 
 	chatActionsBegin
-	NewChatMember         // joined chat participants
-	LeftChatMember        // left chat participants
-	NewChatTitle          // chat title changes
-	NewChatPhoto          // new chat photos
-	DeletedChatPhoto      // deleted chat photos
-	GroupChatCreated      // creation of a group chat
-	SupergroupChatCreated // creation of a supergroup chat
-	ChannelChatCreated    // createion of a channel
-	MigrationToSupergroup // migration to supergroup
-	MigrationFromGroup    // migration from group (to supergroup)
+	NewChatMember         // Joined chat participant.
+	LeftChatMember        // Left chat participant.
+	NewChatTitle          // Chat title change.
+	NewChatPhoto          // New chat photo.
+	DeletedChatPhoto      // Deleted chat photo.
+	GroupChatCreated      // Creation of a group cha.
+	SupergroupChatCreated // Creation of a supergroup cha.
+	ChannelChatCreated    // Createion of a channe.
+	MigrationToSupergroup // Migration to supergrou.
+	MigrationFromGroup    // Migration from group (to supergroup).
 	chatActionsEnd
 
-	UnknownMessage // unknown (probably new due to API changes)
+	UnknownMessage // Unknown (probably new due to API changes).
 )
 
 var messageTypes = map[MessageType]string{
@@ -313,7 +316,7 @@ var messageTypes = map[MessageType]string{
 	UnknownMessage: "Unknown",
 }
 
-// IsChatAction checks if the MessageType is about changes in group chats
+// IsChatAction checks if the MessageType is about changes in group chats.
 func (mt MessageType) IsChatAction() bool {
 	return mt > chatActionsBegin && mt < chatActionsEnd
 }
@@ -326,14 +329,14 @@ func (mt MessageType) String() string {
 	return val
 }
 
-// PhotoSize represents one size of a photo or a thumbnail
+// PhotoSize represents one size of a photo or a thumbnail.
 type PhotoSize struct {
 	FileBase
 	Width  int `json:"width"`
 	Height int `json:"height"`
 }
 
-// Sticker represents a sticker
+// Sticker represents a sticker.
 type Sticker struct {
 	FileBase
 	Width     int       `json:"width"`
@@ -341,25 +344,26 @@ type Sticker struct {
 	Thumbnail PhotoSize `json:"thumb"`
 }
 
-// UpdateResponse represents the response sent by the API for a GetUpdates request
+// UpdateResponse represents the response sent by the API for a GetUpdate
+// request.
 type updateResponse struct {
 	baseResponse
 	Update []Update `json:"result"`
 }
 
-// ByID is a wrapper to sort an []Update by ID
+// ByID is a wrapper to sort an []Update by ID.
 type byID []Update
 
 func (a byID) Len() int           { return len(a) }
 func (a byID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byID) Less(i, j int) bool { return a[i].ID < a[j].ID }
 
-// Sort sorts all the updates contained in an UpdateResponse by their ID
+// Sort sorts all the updates contained in an UpdateResponse by their ID.
 func (resp *updateResponse) sort() {
 	sort.Sort(byID(resp.Update))
 }
 
-// Update represents an incoming update
+// Update represents an incoming update.
 type Update struct {
 	ID                 int                 `json:"update_id"`
 	Message            *Message            `json:"message"`
@@ -368,7 +372,7 @@ type Update struct {
 	CallbackQuery      *CallbackQuery      `json:"callback_query"`
 }
 
-// Type returns the type of the update
+// Type returns the type of the update.
 func (u *Update) Type() UpdateType {
 	if u.Message != nil {
 		return MessageUpdate
@@ -380,16 +384,16 @@ func (u *Update) Type() UpdateType {
 	return UnknownUpdate
 }
 
-// UpdateType represents an update type
+// UpdateType represents an update type.
 type UpdateType int
 
-// Update types
+// Update types.
 const (
-	MessageUpdate            UpdateType = iota // message update
-	InlineQueryUpdate                          // inline query
-	ChosenInlineResultUpdate                   // chosen inline result
+	MessageUpdate            UpdateType = iota // Message update.
+	InlineQueryUpdate                          // Inline query.
+	ChosenInlineResultUpdate                   // Chosen inline result.
 
-	UnknownUpdate // unkown, probably due to API changes
+	UnknownUpdate // Unkown, probably due to API changes.
 )
 
 var updateTypes = map[UpdateType]string{
@@ -408,13 +412,13 @@ func (t UpdateType) String() string {
 	return val
 }
 
-// UserResponse represents the response sent by the API on a GetMe request
+// UserResponse represents the response sent by the API on a GetMe request.
 type UserResponse struct {
 	baseResponse
 	User User `json:"result"`
 }
 
-// User represents a Telegram user or bot
+// User represents a Telegram user or bot.
 type User struct {
 	ID        int     `json:"id"`
 	FirstName string  `json:"first_name"`
@@ -433,19 +437,20 @@ func (u User) String() string {
 	return fmt.Sprintf("%d/%s", u.ID, u.FirstName)
 }
 
-// UserProfilePhotosResponse represents the response sent by the API on a GetUserProfilePhotos request
+// UserProfilePhotosResponse represents the response sent by the API on a
+// GetUserProfilePhotos request.
 type UserProfilePhotosResponse struct {
 	baseResponse
 	UserProfilePhotos UserProfilePhotos `json:"result"`
 }
 
-// UserProfilePhotos represents a users profile pictures
+// UserProfilePhotos represents a users profile pictures.
 type UserProfilePhotos struct {
 	TotalCount int         `json:"total_count"`
 	Photos     []PhotoSize `json:"photos"`
 }
 
-// Video represents a video file
+// Video represents a video file.
 type Video struct {
 	FileBase
 	Width     int       `json:"width"`
@@ -456,34 +461,35 @@ type Video struct {
 	Caption   string    `json:"caption"`
 }
 
-// Voice represents a voice note
+// Voice represents a voice note.
 type Voice struct {
 	FileBase
 	Duration int    `json:"duration"`
 	MimeType string `json:"mime_type"`
 }
 
-// InlineQuery represents an incoming inline query
+// InlineQuery represents an incoming inline query.
 type InlineQuery struct {
-	ID     string `json:"id"`     // unique identifier for this query
-	From   User   `json:"from"`   // sender
-	Query  string `json:"query"`  // text of the query
-	Offset string `json:"offset"` // offset of the results to be returned, can be controlled by the bot
+	ID     string `json:"id"`     // Unique identifier for this query.
+	From   User   `json:"from"`   // Sender.
+	Query  string `json:"query"`  // Text of the query.
+	Offset string `json:"offset"` // Offset of the results to be returned, can be controlled by the bot.
 }
 
-// ChosenInlineResult represents a result of an inline query that was chosen by the user and sent to their chat partner
+// ChosenInlineResult represents a result of an inline query that was
+// chosen by the user and sent to their chat partner.
 type ChosenInlineResult struct {
-	ID    string `json:"result_id"` // unique identifier for the result that was chosen
-	From  User   `json:"from"`      // user that chose the result
-	Query string `json:"query"`     // query that was used to obtain the result
+	ID    string `json:"result_id"` // Unique identifier for the result that was chosen.
+	From  User   `json:"from"`      // User that chose the result.
+	Query string `json:"query"`     // Query that was used to obtain the result.
 }
 
 // CallbackQuery represents an incoming callback query from a button of an
 // inline keyboard.
 type CallbackQuery struct {
-	ID              string   `json:"id"`                // Unique identifier for this query
-	From            User     `json:"from"`              // Sender
-	Message         *Message `json:"message"`           // Message with the callback button that originated the query. (optional)
-	InlineMessageID *string  `json:"inline_message_id"` // Identifier of the message sent via the bot in inline mode, that originated the query
+	ID              string   `json:"id"`                // Unique identifier for this query.
+	From            User     `json:"from"`              // Sender.
+	Message         *Message `json:"message"`           // Message with the callback button that originated the query. (optional).
+	InlineMessageID *string  `json:"inline_message_id"` // Identifier of the message sent via the bot in inline mode, that originated the query.
 	Data            string   `json:"data"`              // Data associated with the callback button. Be aware that a bad client can send arbitrary data in this field.
 }

--- a/other.go
+++ b/other.go
@@ -6,7 +6,7 @@ package tbotapi
 
 import "io"
 
-// Querystring is a type to represent querystring-applicable data
+// Querystring is a type to represent querystring-applicable data.
 type querystring map[string]string
 
 type querystringer interface {

--- a/outgoing.go
+++ b/outgoing.go
@@ -10,13 +10,14 @@ import (
 	"io"
 )
 
-// outgoingBase contains fields shared by most of the outgoing requests
+// outgoingBase contains fields shared by most of the outgoing requests.
 type outgoingBase struct {
 	api       *TelegramBotAPI
 	Recipient Recipient `json:"chat_id"`
 }
 
-// outgoingMessageBase contains fields shared by most of the outgoing messages
+// outgoingMessageBase contains fields shared by most of the outgoing
+// messages.
 type outgoingMessageBase struct {
 	outgoingBase
 	ReplyToMessageID    int         `json:"reply_to_message_id,omitempty"`
@@ -26,21 +27,23 @@ type outgoingMessageBase struct {
 	replyMarkupSet      bool
 }
 
-// SetDisableNotification sets whether notifications should be disabled for this
-// message. (optional)
+// SetDisableNotification sets whether notifications should be disabled for
+// this message (optional).
 func (op *outgoingMessageBase) SetDisableNotification(to bool) {
 	op.DisableNotification = to
 }
 
-// SetReplyToMessageID sets the ID for the message to reply to (optional)
+// SetReplyToMessageID sets the ID for the message to reply to (optional).
 func (op *outgoingMessageBase) SetReplyToMessageID(to int) {
 	op.ReplyToMessageID = to
 	op.replyToMessageIDSet = true
 }
 
 // SetReplyKeyboardMarkup sets the ReplyKeyboardMarkup (optional)
-// Note that only one of ReplyKeyboardMarkup, ReplyKeyboardHide or ForceReply can be set.
-// Attempting to set any of the other two or re-setting this will cause a panic.
+// Note that only one of ReplyKeyboardMarkup, ReplyKeyboardHide or
+// ForceReply can be set.
+// Attempting to set any of the other two or re-setting this will cause a
+// panic.
 func (op *outgoingMessageBase) SetReplyKeyboardMarkup(to ReplyKeyboardMarkup) {
 	if op.replyMarkupSet {
 		panic("Outgoing: Only one of ReplyKeyboardMarkup, ReplyKeyboardHide or ForceReply can be set")
@@ -50,8 +53,10 @@ func (op *outgoingMessageBase) SetReplyKeyboardMarkup(to ReplyKeyboardMarkup) {
 }
 
 // SetReplyKeyboardHide sets the ReplyKeyboardHide (optional)
-// Note that only one of ReplyKeyboardMarkup, ReplyKeyboardHide or ForceReply can be set.
-// Attempting to set any of the other two or re-setting this will cause a panic.
+// Note that only one of ReplyKeyboardMarkup, ReplyKeyboardHide or
+// ForceReply can be set.
+// Attempting to set any of the other two or re-setting this will cause a
+// panic.
 func (op *outgoingMessageBase) SetReplyKeyboardHide(to ReplyKeyboardHide) {
 	if !to.HideKeyboard {
 		return
@@ -65,8 +70,10 @@ func (op *outgoingMessageBase) SetReplyKeyboardHide(to ReplyKeyboardHide) {
 }
 
 // SetForceReply sets ForceReply for this message (optional)
-// Note that only one of ReplyKeyboardMarkup, ReplyKeyboardHide or ForceReply can be set.
-// Attempting to set any of the other two or re-setting this will cause a panic.
+// Note that only one of ReplyKeyboardMarkup, ReplyKeyboardHide or
+// ForceReply can be set.
+// Attempting to set any of the other two or re-setting this will cause a
+// panic.
 func (op *outgoingMessageBase) SetForceReply(to ForceReply) {
 	if !to.ForceReply {
 		return
@@ -79,7 +86,7 @@ func (op *outgoingMessageBase) SetForceReply(to ForceReply) {
 	op.ReplyMarkup = ReplyMarkup(to)
 }
 
-// getBaseQueryString gets a Querystring representing this message
+// getBaseQueryString gets a Querystring representing this message.
 func (op *outgoingBase) getBaseQueryString() querystring {
 	toReturn := map[string]string{}
 	if op.Recipient.isChannel() {
@@ -92,11 +99,11 @@ func (op *outgoingBase) getBaseQueryString() querystring {
 	return querystring(toReturn)
 }
 
-// getMessageBaseQueryString gets a Querystring representing this message
+// getMessageBaseQueryString gets a Querystring representing this message.
 func (op *outgoingMessageBase) getBaseQueryString() querystring {
 	toReturn := map[string]string{}
 	if op.Recipient.isChannel() {
-		//Channel
+		//Channel.
 		toReturn["chat_id"] = fmt.Sprint(*op.Recipient.ChannelID)
 	} else {
 		toReturn["chat_id"] = fmt.Sprint(*op.Recipient.ChatID)
@@ -139,7 +146,7 @@ func (b outgoingFileBase) isResend() bool {
 	return b.fileName == "" && b.r == nil && b.fileID != ""
 }
 
-// OutgoingAudio represents an outgoing audio file
+// OutgoingAudio represents an outgoing audio file.
 type OutgoingAudio struct {
 	outgoingMessageBase
 	outgoingFileBase
@@ -148,25 +155,25 @@ type OutgoingAudio struct {
 	Performer string `json:"performer,omitempty"`
 }
 
-// SetDuration sets a duration for the audio file (optional)
+// SetDuration sets a duration for the audio file (optional).
 func (oa *OutgoingAudio) SetDuration(to int) *OutgoingAudio {
 	oa.Duration = to
 	return oa
 }
 
-// SetPerformer sets a performer for the audio file (optional)
+// SetPerformer sets a performer for the audio file (optional).
 func (oa *OutgoingAudio) SetPerformer(to string) *OutgoingAudio {
 	oa.Performer = to
 	return oa
 }
 
-// SetTitle sets a title for the audio file (optional)
+// SetTitle sets a title for the audio file (optional).
 func (oa *OutgoingAudio) SetTitle(to string) *OutgoingAudio {
 	oa.Title = to
 	return oa
 }
 
-// querystring implements querystringer to represent the audio file
+// querystring implements querystringer to represent the audio file.
 func (oa *OutgoingAudio) querystring() querystring {
 	toReturn := map[string]string(oa.getBaseQueryString())
 
@@ -185,25 +192,25 @@ func (oa *OutgoingAudio) querystring() querystring {
 	return querystring(toReturn)
 }
 
-// OutgoingDocument represents an outgoing file
+// OutgoingDocument represents an outgoing file.
 type OutgoingDocument struct {
 	outgoingMessageBase
 	outgoingFileBase
 }
 
-// querystring implements querystringer to represent the outgoing file
+// querystring implements querystringer to represent the outgoing file.
 func (od *OutgoingDocument) querystring() querystring {
 	return od.getBaseQueryString()
 }
 
-// OutgoingForward represents an outgoing, forwarded message
+// OutgoingForward represents an outgoing, forwarded message.
 type OutgoingForward struct {
 	outgoingMessageBase
 	FromChatID Recipient `json:"from_chat_id"`
 	MessageID  int       `json:"message_id"`
 }
 
-// OutgoingLocation represents an outgoing location on a map
+// OutgoingLocation represents an outgoing location on a map.
 type OutgoingLocation struct {
 	outgoingMessageBase
 	Latitude  float32 `json:"latitude"`
@@ -220,13 +227,13 @@ type OutgoingVenue struct {
 	FoursquareID string  `json:"foursquare_id,omitempty"`
 }
 
-// SetFoursquareID sets the foursquare ID for the venue. (optional)
+// SetFoursquareID sets the foursquare ID for the venue (optional).
 func (ov *OutgoingVenue) SetFoursquareID(to string) *OutgoingVenue {
 	ov.FoursquareID = to
 	return ov
 }
 
-// OutgoingMessage represents an outgoing message
+// OutgoingMessage represents an outgoing message.
 type OutgoingMessage struct {
 	outgoingMessageBase
 	Text                  string    `json:"text"`
@@ -234,7 +241,8 @@ type OutgoingMessage struct {
 	ParseMode             ParseMode `json:"parse_mode,omitempty"`
 }
 
-// SetMarkdown sets or resets whether the message should be parsed as markdown or plain text (optional)
+// SetMarkdown sets or resets whether the message should be parsed as
+// markdown or plain text (optional).
 func (om *OutgoingMessage) SetMarkdown(to bool) *OutgoingMessage {
 	if to {
 		om.ParseMode = ModeMarkdown
@@ -244,7 +252,8 @@ func (om *OutgoingMessage) SetMarkdown(to bool) *OutgoingMessage {
 	return om
 }
 
-// SetHTML sets or resets whether the message should be parsed as HTML or plain text (optional)
+// SetHTML sets or resets whether the message should be parsed as HTML or
+// plain text (optional).
 func (om *OutgoingMessage) SetHTML(to bool) *OutgoingMessage {
 	if to {
 		om.ParseMode = ModeHTML
@@ -254,26 +263,27 @@ func (om *OutgoingMessage) SetHTML(to bool) *OutgoingMessage {
 	return om
 }
 
-// SetDisableWebPagePreview disables web page previews for the message (optional)
+// SetDisableWebPagePreview disables web page previews for the message
+// (optional).
 func (om *OutgoingMessage) SetDisableWebPagePreview(to bool) *OutgoingMessage {
 	om.DisableWebPagePreview = to
 	return om
 }
 
-// OutgoingPhoto represents an outgoing photo
+// OutgoingPhoto represents an outgoing photo.
 type OutgoingPhoto struct {
 	outgoingMessageBase
 	outgoingFileBase
 	Caption string `json:"caption,omitempty"`
 }
 
-// SetCaption sets a caption for the photo (optional)
+// SetCaption sets a caption for the photo (optional).
 func (op *OutgoingPhoto) SetCaption(to string) *OutgoingPhoto {
 	op.Caption = to
 	return op
 }
 
-// querystring implements querystringer to represent the photo
+// querystring implements querystringer to represent the photo.
 func (op *OutgoingPhoto) querystring() querystring {
 	toReturn := map[string]string(op.getBaseQueryString())
 
@@ -284,13 +294,13 @@ func (op *OutgoingPhoto) querystring() querystring {
 	return querystring(toReturn)
 }
 
-// OutgoingSticker represents an outgoing sticker message
+// OutgoingSticker represents an outgoing sticker message.
 type OutgoingSticker struct {
 	outgoingMessageBase
 	outgoingFileBase
 }
 
-// querystring implements querystringer to represent the sticker message
+// querystring implements querystringer to represent the sticker message.
 func (os *OutgoingSticker) querystring() querystring {
 	return os.getBaseQueryString()
 }
@@ -312,12 +322,13 @@ type OutgoingUnbanChatMember struct {
 // OutgoingCallbackQueryResponse represents a response to a callback query.
 type OutgoingCallbackQueryResponse struct {
 	api             *TelegramBotAPI
-	CallbackQueryID string `json:"callback_query_id"` // ID of the callback query
+	CallbackQueryID string `json:"callback_query_id"` // ID of the callback query.
 	Text            string `json:"text,omitempty"`
 	ShowAlert       bool   `json:"show_alert,omitempty"`
 }
 
-// OutgoingUserProfilePhotosRequest represents a request for a users profile photos
+// OutgoingUserProfilePhotosRequest represents a request for a users
+// profile photos.
 type OutgoingUserProfilePhotosRequest struct {
 	api    *TelegramBotAPI
 	UserID int `json:"user_id"`
@@ -325,19 +336,19 @@ type OutgoingUserProfilePhotosRequest struct {
 	Limit  int `json:"limit,omitempty"`
 }
 
-// SetOffset sets an offset for the request (optional)
+// SetOffset sets an offset for the request (optional).
 func (op *OutgoingUserProfilePhotosRequest) SetOffset(to int) *OutgoingUserProfilePhotosRequest {
 	op.Offset = to
 	return op
 }
 
-// SetLimit sets a limit for the request (optional)
+// SetLimit sets a limit for the request (optional).
 func (op *OutgoingUserProfilePhotosRequest) SetLimit(to int) *OutgoingUserProfilePhotosRequest {
 	op.Limit = to
 	return op
 }
 
-// querystring implements querystringer to represent the request
+// querystring implements querystringer to represent the request.
 func (op *OutgoingUserProfilePhotosRequest) querystring() querystring {
 	toReturn := map[string]string{}
 	toReturn["user_id"] = fmt.Sprint(op.UserID)
@@ -353,7 +364,7 @@ func (op *OutgoingUserProfilePhotosRequest) querystring() querystring {
 	return querystring(toReturn)
 }
 
-// OutgoingVideo represents an outgoing video file
+// OutgoingVideo represents an outgoing video file.
 type OutgoingVideo struct {
 	outgoingMessageBase
 	outgoingFileBase
@@ -361,19 +372,20 @@ type OutgoingVideo struct {
 	Caption  string `json:"caption,omitempty"`
 }
 
-// SetCaption sets a caption for the video file (optional)
+// SetCaption sets a caption for the video file (optional).
 func (ov *OutgoingVideo) SetCaption(to string) *OutgoingVideo {
 	ov.Caption = to
 	return ov
 }
 
-// SetDuration sets a duration for the video file (optional)
+// SetDuration sets a duration for the video file (optional).
 func (ov *OutgoingVideo) SetDuration(to int) *OutgoingVideo {
 	ov.Duration = to
 	return ov
 }
 
-// querystring implements querystringer to represent the outgoing video file
+// querystring implements querystringer to represent the outgoing video
+// file.
 func (ov *OutgoingVideo) querystring() querystring {
 	toReturn := map[string]string(ov.getBaseQueryString())
 
@@ -388,20 +400,21 @@ func (ov *OutgoingVideo) querystring() querystring {
 	return querystring(toReturn)
 }
 
-// OutgoingVoice represents an outgoing voice note
+// OutgoingVoice represents an outgoing voice note.
 type OutgoingVoice struct {
 	outgoingMessageBase
 	outgoingFileBase
 	Duration int `json:"duration,omitempty"`
 }
 
-// SetDuration sets a duration of the voice note (optional)
+// SetDuration sets a duration of the voice note (optional).
 func (ov *OutgoingVoice) SetDuration(to int) *OutgoingVoice {
 	ov.Duration = to
 	return ov
 }
 
-// querystring implements querystringer to represent the outgoing voice note
+// querystring implements querystringer to represent the outgoing voice
+// note.
 func (ov *OutgoingVoice) querystring() querystring {
 	toReturn := map[string]string(ov.getBaseQueryString())
 
@@ -436,15 +449,18 @@ type InlineKeyboardButton struct {
 	SwitchInlineQuery string `json:"switch_inline_query,omitempty"`
 }
 
-// ForceReply represents the values sent by a bot so that clients will be presented with a forced reply, see https://core.telegram.org/bots/api#forcereply
+// ForceReply represents the values sent by a bot so that clients will be
+// presented with a forced reply,
+// see https://core.telegram.org/bots/api#forcereply
 type ForceReply struct {
 	ForceReply bool `json:"force_reply"`
 	Selective  bool `json:"selective"`
 }
 
-// ReplyKeyboardMarkup represents a custom keyboard with reply options to be presented to clients
+// ReplyKeyboardMarkup represents a custom keyboard with reply options to
+// be presented to clients.
 type ReplyKeyboardMarkup struct {
-	Keyboard        [][]KeyboardButton `json:"keyboard"` // slice of keyboard lines
+	Keyboard        [][]KeyboardButton `json:"keyboard"` // Slice of keyboard lines.
 	ResizeKeyboard  bool               `json:"resize_keyboard"`
 	OneTimeKeyboard bool               `json:"one_time_keyboard"`
 	Selective       bool               `json:"selective"`
@@ -457,32 +473,35 @@ type KeyboardButton struct {
 	RequestLocation bool   `json:"request_location"`
 }
 
-// ReplyKeyboardHide contains the fields necessary to hide a custom keyboard
+// ReplyKeyboardHide contains the fields necessary to hide a custom
+// keyboard.
 type ReplyKeyboardHide struct {
 	HideKeyboard bool `json:"hide_keyboard"`
 	Selective    bool `json:"selective"`
 }
 
-// ParseMode describes how a message should be parsed client-side
+// ParseMode describes how a message should be parsed client-side.
 type ParseMode string
 
-//ParseModes
+//ParseModes.
 const (
-	ModeMarkdown = ParseMode("Markdown") // parse as Markdown
-	ModeHTML     = ParseMode("HTML")     // parse as HTML
-	ModeDefault  = ParseMode("")         // parse as text
+	ModeMarkdown = ParseMode("Markdown") // Parse as Markdown.
+	ModeHTML     = ParseMode("HTML")     // Parse as HTML.
+	ModeDefault  = ParseMode("")         // Parse as text.
 )
 
-// OutgoingChatAction represents an outgoing chat action
+// OutgoingChatAction represents an outgoing chat action.
 type OutgoingChatAction struct {
 	outgoingBase
 	Action ChatAction `json:"action"`
 }
 
-// ChatAction represents an action to be shown to clients, indicating activity of the bot
+// ChatAction represents an action to be shown to clients, indicating
+// activity of the bot.
 type ChatAction string
 
-// Represents all the possible ChatActions to be sent, see https://core.telegram.org/bots/api#sendchataction
+// Represents all the possible ChatActions to be sent,
+// see https://core.telegram.org/bots/api#sendchataction
 const (
 	ChatActionTyping         ChatAction = "typing"
 	ChatActionUploadPhoto               = "upload_photo"
@@ -498,17 +517,17 @@ const (
 // For limitations, check the API documentation.
 type InlineQueryAnswer struct {
 	api        *TelegramBotAPI
-	QueryID    string              `json:"inline_query_id"`       // unique identifier for the answered query
-	Results    []InlineQueryResult `json:"results"`               // results for the query
-	CacheTime  int                 `json:"cache_time,omitempty"`  // the maximum amount of time in seconds that the result of the query may be cached
-	Personal   bool                `json:"is_personal,omitempty"` // if set to true, results will be cached for that user onl
-	NextOffset string              `json:"next_offset,omitempty"` // the offset that a client should send in the next query with the same text to receive more results
+	QueryID    string              `json:"inline_query_id"`       // Unique identifier for the answered query.
+	Results    []InlineQueryResult `json:"results"`               // Results for the query.
+	CacheTime  int                 `json:"cache_time,omitempty"`  // The maximum amount of time in seconds that the result of the query may be cached.
+	Personal   bool                `json:"is_personal,omitempty"` // If set to true, results will be cached for that user onl.
+	NextOffset string              `json:"next_offset,omitempty"` // The offset that a client should send in the next query with the same text to receive more results.
 }
 
-// InlineQueryResultType represents a type of an inline query result
+// InlineQueryResultType represents a type of an inline query result.
 type InlineQueryResultType string
 
-// Inline query result type constants
+// Inline query result type constants.
 const (
 	ArticleResult  = InlineQueryResultType("article")
 	PhotoResult    = InlineQueryResultType("photo")
@@ -517,16 +536,17 @@ const (
 	VideoResult    = InlineQueryResultType("video")
 )
 
-// InlineQueryResultBase is the base for all InlineQueryResults
+// InlineQueryResultBase is the base for all InlineQueryResults.
 type InlineQueryResultBase struct {
-	Type                  InlineQueryResultType `json:"type"`                               // type of the result
-	ID                    string                `json:"id"`                                 // unique identifier for this result, 1-64 bytes
-	ParseMode             ParseMode             `json:"parse_mode,omitempty"`               // indicates how to parse client-side (optional)
-	DisableWebPagePreview bool                  `json:"disable_web_page_preview,omitempty"` // disables link previews (optional)
+	Type                  InlineQueryResultType `json:"type"`                               // Type of the result.
+	ID                    string                `json:"id"`                                 // Unique identifier for this result, 1-64 bytes.
+	ParseMode             ParseMode             `json:"parse_mode,omitempty"`               // Indicates how to parse client-side (optional).
+	DisableWebPagePreview bool                  `json:"disable_web_page_preview,omitempty"` // Disables link previews (optional).
 }
 
 // InlineQueryResult is a marker interface for query results.
-// It is implemented by pointers to InlineQueryResult(Article|Photo|Gif|Mpeg4Gif|Video).
+// It is implemented by pointers to
+// InlineQueryResult(Article|Photo|Gif|Mpeg4Gif|Video).
 type InlineQueryResult interface {
 	result()
 }
@@ -537,20 +557,21 @@ func (*InlineQueryResultGif) result()      {}
 func (*InlineQueryResultMpeg4Gif) result() {}
 func (*InlineQueryResultVideo) result()    {}
 
-// InlineQueryResultArticle represents a link to an article or web page
+// InlineQueryResultArticle represents a link to an article or web page.
 type InlineQueryResultArticle struct {
 	InlineQueryResultBase
-	Title       string `json:"title"`                  // title of the result
-	Text        string `json:"message_text"`           // text of the message to be sent
-	URL         string `json:"url,omitempty"`          // URL of the result (optional)
-	HideURL     bool   `json:"hide_url,omitempty"`     // whether to hide the URL in the message (optional)
-	Description string `json:"description,omitempty"`  // short description of the result (optional)
-	ThumbURL    string `json:"thumb_url,omitempty"`    // URL of the thumbnail for the result (optional)
-	ThumbWidth  int    `json:"thumb_width,omitempty"`  // thumbnail width (optional)
-	ThumbHeight int    `json:"thumb_height,omitempty"` // thumbnail height (optional)
+	Title       string `json:"title"`                  // Title of the result.
+	Text        string `json:"message_text"`           // Text of the message to be sent.
+	URL         string `json:"url,omitempty"`          // URL of the result (optional).
+	HideURL     bool   `json:"hide_url,omitempty"`     // Whether to hide the URL in the message (optional).
+	Description string `json:"description,omitempty"`  // Short description of the result (optional).
+	ThumbURL    string `json:"thumb_url,omitempty"`    // URL of the thumbnail for the result (optional).
+	ThumbWidth  int    `json:"thumb_width,omitempty"`  // Thumbnail width (optional).
+	ThumbHeight int    `json:"thumb_height,omitempty"` // Thumbnail height (optional).
 }
 
-// NewInlineQueryResultArticle returns a new InlineQueryResultArticle with all mandatory fields set
+// NewInlineQueryResultArticle returns a new InlineQueryResultArticle with
+// all mandatory fields set.
 func NewInlineQueryResultArticle(id, title, text string) *InlineQueryResultArticle {
 	return &InlineQueryResultArticle{
 		InlineQueryResultBase: InlineQueryResultBase{
@@ -562,25 +583,27 @@ func NewInlineQueryResultArticle(id, title, text string) *InlineQueryResultArtic
 	}
 }
 
-// InlineQueryResultFileOptionals contains optional fields that all inline query file-like results support.
+// InlineQueryResultFileOptionals contains optional fields that all inline
+// query file-like results support.
 type InlineQueryResultFileOptionals struct {
-	Caption string `json:"caption,omitempty"`      // caption of the file to be sent, for limitations check the API documentation (optional)
-	Text    string `json:"message_text,omitempty"` // text of a message to be sent instead of the file, for limitations check the API documentation (optional)
+	Caption string `json:"caption,omitempty"`      // Caption of the file to be sent, for limitations check the API documentation (optional).
+	Text    string `json:"message_text,omitempty"` // Text of a message to be sent instead of the file, for limitations check the API documentation (optional).
 }
 
-// InlineQueryResultPhoto represents a link to a photo
+// InlineQueryResultPhoto represents a link to a photo.
 type InlineQueryResultPhoto struct {
 	InlineQueryResultBase
-	PhotoURL    string `json:"photo_url"`              // valid URL of the photo
-	ThumbURL    string `json:"thumb_url"`              // URL of the thumbnail for the photo
-	PhotoWidth  int    `json:"photo_width,omitempty"`  // width of the photo (optional)
-	PhotoHeight int    `json:"photo_height,omitempty"` // height of the photo (optional)
-	Title       string `json:"title,omitempty"`        // title for the result (optional)
-	Description string `json:"description,omitempty"`  // description of the result (optional)
+	PhotoURL    string `json:"photo_url"`              // Valid URL of the photo.
+	ThumbURL    string `json:"thumb_url"`              // URL of the thumbnail for the photo.
+	PhotoWidth  int    `json:"photo_width,omitempty"`  // Width of the photo (optional).
+	PhotoHeight int    `json:"photo_height,omitempty"` // Height of the photo (optional).
+	Title       string `json:"title,omitempty"`        // Title for the result (optional).
+	Description string `json:"description,omitempty"`  // Description of the result (optional).
 	InlineQueryResultFileOptionals
 }
 
-// NewInlineQueryResultPhoto returns a new InlineQueryResultPhoto with all mandatory fields set
+// NewInlineQueryResultPhoto returns a new InlineQueryResultPhoto with all
+// mandatory fields set.
 func NewInlineQueryResultPhoto(id, photoURL, thumbURL string) *InlineQueryResultPhoto {
 	return &InlineQueryResultPhoto{
 		InlineQueryResultBase: InlineQueryResultBase{
@@ -592,18 +615,19 @@ func NewInlineQueryResultPhoto(id, photoURL, thumbURL string) *InlineQueryResult
 	}
 }
 
-// InlineQueryResultGif represents a link to an animated GIF file
+// InlineQueryResultGif represents a link to an animated GIF file.
 type InlineQueryResultGif struct {
 	InlineQueryResultBase
-	GifURL    string `json:"gif_url"`              // valid URL for the GIF file
-	ThumbURL  string `json:"thumb_url"`            // URL of the static thumbnail for the result
-	GifWidth  int    `json:"gif_width,omitempty"`  // width of the GIF (optional)
-	GifHeight int    `json:"gif_height,omitempty"` // height of the GIF (optional)
-	Title     string `json:"title,omitempty"`      // title for the result (optional)
+	GifURL    string `json:"gif_url"`              // Valid URL for the GIF file.
+	ThumbURL  string `json:"thumb_url"`            // URL of the static thumbnail for the result.
+	GifWidth  int    `json:"gif_width,omitempty"`  // Width of the GIF (optional).
+	GifHeight int    `json:"gif_height,omitempty"` // Height of the GIF (optional).
+	Title     string `json:"title,omitempty"`      // Title for the result (optional).
 	InlineQueryResultFileOptionals
 }
 
-// NewInlineQueryResultGif returns a new InlineQueryResultGif with all mandatory fields set
+// NewInlineQueryResultGif returns a new InlineQueryResultGif with all
+// mandatory fields set.
 func NewInlineQueryResultGif(id, gifURL, thumbURL string) *InlineQueryResultGif {
 	return &InlineQueryResultGif{
 		InlineQueryResultBase: InlineQueryResultBase{
@@ -615,18 +639,20 @@ func NewInlineQueryResultGif(id, gifURL, thumbURL string) *InlineQueryResultGif 
 	}
 }
 
-// InlineQueryResultMpeg4Gif represents a link to a video animation (without sound)
+// InlineQueryResultMpeg4Gif represents a link to a video animation
+// (without sound).
 type InlineQueryResultMpeg4Gif struct {
 	InlineQueryResultBase
-	Mpeg4URL    string `json:"mpeg4_url"`              // valid URL for the MP4 file
-	ThumbURL    string `json:"thumb_url"`              // URL of the static thumbnail for the result
-	Mpeg4Width  int    `json:"mpeg4_width,omitempty"`  // video width (optional)
-	Mpeg4Height int    `json:"mpeg4_height,omitempty"` // video height (optional)
-	Title       string `json:"title,omitempty"`        // title for the result (optional)
+	Mpeg4URL    string `json:"mpeg4_url"`              // Valid URL for the MP4 file.
+	ThumbURL    string `json:"thumb_url"`              // URL of the static thumbnail for the result.
+	Mpeg4Width  int    `json:"mpeg4_width,omitempty"`  // Video width (optional).
+	Mpeg4Height int    `json:"mpeg4_height,omitempty"` // Video height (optional).
+	Title       string `json:"title,omitempty"`        // Title for the result (optional).
 	InlineQueryResultFileOptionals
 }
 
-// NewInlineQueryResultMpeg4Gif returns a new InlineQueryResultMpeg4Gif with all mandatory fields set
+// NewInlineQueryResultMpeg4Gif returns a new InlineQueryResultMpeg4Gif
+// with all mandatory fields set.
 func NewInlineQueryResultMpeg4Gif(id, mpeg4URL, thumbURL string) *InlineQueryResultMpeg4Gif {
 	return &InlineQueryResultMpeg4Gif{
 		InlineQueryResultBase: InlineQueryResultBase{
@@ -638,31 +664,32 @@ func NewInlineQueryResultMpeg4Gif(id, mpeg4URL, thumbURL string) *InlineQueryRes
 	}
 }
 
-// MIMEType represents a MIME type
+// MIMEType represents a MIME type.
 type MIMEType string
 
-// MIME type constants for an InlineQueryResultVideo
+// MIME type constants for an InlineQueryResultVideo.
 const (
 	MIMETextHTML = MIMEType("text/html")
 	MIMEVideoMP4 = MIMEType("video/mp4")
 )
 
-// InlineQueryResultVideo represents a link to a video player/file
+// InlineQueryResultVideo represents a link to a video player/file.
 type InlineQueryResultVideo struct {
 	InlineQueryResultBase
-	VideoURL      string   `json:"video_url"`                // valid URL for the video player/file
-	MIMEType      MIMEType `json:"mime_type"`                // MIME type of the content of the URL
-	ThumbURL      string   `json:"thumb_url"`                // URL of the static thumbnail
-	Title         string   `json:"title"`                    // title for the result
-	Text          string   `json:"message_text"`             // text of the message to be sent with the video, for limitations check the API documentation
-	VideoWidth    int      `json:"video_width,omitempty"`    // video width (optional)
-	VideoHeight   int      `json:"video_height,omitempty"`   // video height (optional)
-	VideoDuration int      `json:"video_duration,omitempty"` // video duration in seconds (optional)
-	Description   string   `json:"description"`              // short description of the result (optional)
+	VideoURL      string   `json:"video_url"`                // Valid URL for the video player/file.
+	MIMEType      MIMEType `json:"mime_type"`                // MIME type of the content of the URL.
+	ThumbURL      string   `json:"thumb_url"`                // URL of the static thumbnail.
+	Title         string   `json:"title"`                    // Title for the result.
+	Text          string   `json:"message_text"`             // Text of the message to be sent with the video, for limitations check the API documentation.
+	VideoWidth    int      `json:"video_width,omitempty"`    // Video width (optional).
+	VideoHeight   int      `json:"video_height,omitempty"`   // Video height (optional).
+	VideoDuration int      `json:"video_duration,omitempty"` // Video duration in seconds (optional).
+	Description   string   `json:"description"`              // Short description of the result (optional).
 	InlineQueryResultFileOptionals
 }
 
-// NewInlineQueryResultVideo returns a new InlineQueryResultVideo with all mandatory fields set
+// NewInlineQueryResultVideo returns a new InlineQueryResultVideo with all
+// mandatory fields set.
 func NewInlineQueryResultVideo(id, videoURL, thumbURL, title, text string, mimeType MIMEType) *InlineQueryResultVideo {
 	return &InlineQueryResultVideo{
 		InlineQueryResultBase: InlineQueryResultBase{

--- a/rest.go
+++ b/rest.go
@@ -68,10 +68,10 @@ func (c *client) uploadFile(m method, result interface{}, data file, fields quer
 }
 
 func parseResponseBody(c *resty.Client, res *resty.Response) (err error) {
-	// Handles only JSON
+	// Handles only JSON.
 	ct := res.Header().Get(http.CanonicalHeaderKey("Content-Type"))
 	if resty.IsJSONType(ct) {
-		// Considered as Result
+		// Considered as Result.
 		if res.StatusCode() > 199 && res.StatusCode() < 500 {
 			if res.Request.Result != nil {
 				err = json.Unmarshal(res.Body(), res.Request.Result)

--- a/sendable.go
+++ b/sendable.go
@@ -34,7 +34,8 @@ func (of *OutgoingForward) Send() (*MessageResponse, error) {
 
 // Send sends the video.
 // Note that the Telegram servers may check the fileName for its extension.
-// For current limitations on what bots can send, please check the API documentation.
+// For current limitations on what bots can send, please check the API
+// documentation.
 // On success, the sent message is returned as a MessageResponse.
 func (ov *OutgoingVideo) Send() (*MessageResponse, error) {
 	return ov.api.send(ov)
@@ -42,7 +43,8 @@ func (ov *OutgoingVideo) Send() (*MessageResponse, error) {
 
 // Send sends the photo.
 // Note that the Telegram servers may check the fileName for its extension.
-// For current limitations on what bots can send, please check the API documentation.
+// For current limitations on what bots can send, please check the API
+// documentation.
 // On success, the sent message is returned as a MessageResponse.
 func (op *OutgoingPhoto) Send() (*MessageResponse, error) {
 	return op.api.send(op)
@@ -50,7 +52,8 @@ func (op *OutgoingPhoto) Send() (*MessageResponse, error) {
 
 // Send sends the sticker.
 // Note that the Telegram servers may check the fileName for its extension.
-// For current limitations on what bots can send, please check the API documentation.
+// For current limitations on what bots can send, please check the API
+// documentation.
 // On success, the sent message is returned as a MessageResponse.
 func (os *OutgoingSticker) Send() (*MessageResponse, error) {
 	return os.api.send(os)
@@ -58,7 +61,8 @@ func (os *OutgoingSticker) Send() (*MessageResponse, error) {
 
 // Send sends the audio.
 // Note that the Telegram servers may check the fileName for its extension.
-// For current limitations on what bots can send, please check the API documentation.
+// For current limitations on what bots can send, please check the API
+// documentation.
 // On success, the sent message is returned as a MessageResponse.
 func (oa *OutgoingAudio) Send() (*MessageResponse, error) {
 	return oa.api.send(oa)
@@ -66,7 +70,8 @@ func (oa *OutgoingAudio) Send() (*MessageResponse, error) {
 
 // Send sends the voice message.
 // Note that the Telegram servers may check the fileName for its extension.
-// For current limitations on what bots can send, please check the API documentation.
+// For current limitations on what bots can send, please check the API
+// documentation.
 // On success, the sent message is returned as a MessageResponse.
 func (ov *OutgoingVoice) Send() (*MessageResponse, error) {
 	return ov.api.send(ov)
@@ -74,7 +79,8 @@ func (ov *OutgoingVoice) Send() (*MessageResponse, error) {
 
 // Send sends the document.
 // Note that the Telegram servers may check the fileName for its extension.
-// For current limitations on what bots can send, please check the API documentation.
+// For current limitations on what bots can send, please check the API
+// documentation.
 // On success, the sent message is returned as a MessageResponse.
 func (od *OutgoingDocument) Send() (*MessageResponse, error) {
 	return od.api.send(od)
@@ -97,7 +103,7 @@ func (op *OutgoingUserProfilePhotosRequest) Send() (*UserProfilePhotosResponse, 
 }
 
 // Send sends the chat action.
-// On success, nil is returned
+// On success, nil is returned.
 func (oc *OutgoingChatAction) Send() error {
 	resp := &baseResponse{}
 	_, err := oc.api.c.postJSON(sendChatAction, resp, oc)
@@ -113,7 +119,7 @@ func (oc *OutgoingChatAction) Send() error {
 }
 
 // Send sends the inline query answer.
-// On success, nil is returned
+// On success, nil is returned.
 func (ia *InlineQueryAnswer) Send() error {
 	resp := &baseResponse{}
 	_, err := ia.api.c.postJSON(answerInlineQuery, resp, ia)

--- a/shared.go
+++ b/shared.go
@@ -6,29 +6,29 @@ package tbotapi
 
 import "fmt"
 
-// Recipient represents the recipient of a message
+// Recipient represents the recipient of a message.
 type Recipient struct {
 	ChatID    *int
 	ChannelID *string
 }
 
-// NewChatRecipient creates a new recipient for private or group chats
+// NewChatRecipient creates a new recipient for private or group chats.
 func NewChatRecipient(chatID int) Recipient {
 	return Recipient{
 		ChatID: &chatID,
 	}
 }
 
-// NewChannelRecipient creates a new recipient for channels
+// NewChannelRecipient creates a new recipient for channels.
 func NewChannelRecipient(channelName string) Recipient {
 	return Recipient{
 		ChannelID: &channelName,
 	}
 }
 
-// NewRecipientFromChat creates a recipient that addresses the given chat
+// NewRecipientFromChat creates a recipient that addresses the given chat.
 func NewRecipientFromChat(chat Chat) Recipient {
-	return NewChatRecipient(chat.ID) //No need to distinguish between channels and chats, bots cannot receive from channels
+	return NewChatRecipient(chat.ID) //No need to distinguish between channels and chats, bots cannot receive from channels.
 }
 
 func (r Recipient) isChat() bool {
@@ -39,7 +39,7 @@ func (r Recipient) isChannel() bool {
 	return r.ChannelID != nil
 }
 
-// MarshalJSON marshals the recipient to JSON
+// MarshalJSON marshals the recipient to JSON.
 func (r Recipient) MarshalJSON() ([]byte, error) {
 	toReturn := ""
 


### PR DESCRIPTION
I've limited the length of all the special comment block on the `.go` files. I've used an `awk` script to do it, checked all the special comments character count and none of them gave a length higher than 78 characters including the `//` chars.
